### PR TITLE
codescan issues

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -89,6 +89,11 @@ jobs:
     name: Auto Assign Issues and PRs
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' || github.event_name == 'pull_request'
+    env:
+      BACKEND_MAINTAINER: ${{ secrets.BACKEND_MAINTAINER }}
+      FRONTEND_MAINTAINER: ${{ secrets.FRONTEND_MAINTAINER }}
+      DEVOPS_MAINTAINER: ${{ secrets.DEVOPS_MAINTAINER }}
+      SECURITY_MAINTAINER: ${{ secrets.SECURITY_MAINTAINER }}
 
     steps:
     - name: Auto assign based on labels
@@ -98,31 +103,44 @@ jobs:
           const labels = context.payload[context.eventName].labels.map(label => label.name);
           const assignees = [];
           
+          // Define assignee mappings - use actual GitHub usernames
+          // These can be configured via repository secrets or environment variables
+          const assigneeMappings = {
+            'backend': process.env.BACKEND_MAINTAINER || 'argakiig', // Default to repo owner
+            'frontend': process.env.FRONTEND_MAINTAINER || 'argakiig',
+            'devops': process.env.DEVOPS_MAINTAINER || 'argakiig',
+            'security': process.env.SECURITY_MAINTAINER || 'argakiig'
+          };
+          
           // Assign based on labels
-          if (labels.includes('backend')) {
-            assignees.push('backend-maintainer');
-          }
-          if (labels.includes('frontend')) {
-            assignees.push('frontend-maintainer');
-          }
-          if (labels.includes('devops')) {
-            assignees.push('devops-maintainer');
-          }
-          if (labels.includes('security')) {
-            assignees.push('security-team');
+          for (const label of labels) {
+            if (assigneeMappings[label]) {
+              assignees.push(assigneeMappings[label]);
+            }
           }
           
-          // Add assignees if not already assigned
-          const currentAssignees = context.payload[context.eventName].assignees.map(assignee => assignee.login);
-          const newAssignees = assignees.filter(assignee => !currentAssignees.includes(assignee));
-          
-          if (newAssignees.length > 0) {
-            await github.rest.issues.addAssignees({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              assignees: newAssignees
-            });
+          // Only proceed if we have valid assignees
+          if (assignees.length > 0) {
+            // Add assignees if not already assigned
+            const currentAssignees = context.payload[context.eventName].assignees.map(assignee => assignee.login);
+            const newAssignees = assignees.filter(assignee => !currentAssignees.includes(assignee));
+            
+            if (newAssignees.length > 0) {
+              try {
+                await github.rest.issues.addAssignees({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  assignees: newAssignees
+                });
+                console.log(`Successfully assigned: ${newAssignees.join(', ')}`);
+              } catch (error) {
+                console.log(`Failed to assign users: ${error.message}`);
+                console.log('This might be because the users are not valid GitHub usernames or do not have access to this repository.');
+              }
+            }
+          } else {
+            console.log('No valid assignees found for the current labels.');
           }
 
   stale-issues:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     name: Code Quality Check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,13 @@
 name: Deploy
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: write
+  deployments: write
+  packages: write
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: write
+  deployments: write
+  packages: write
+
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/test-environments.yml
+++ b/.github/workflows/test-environments.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 6 * * 0'  # Weekly on Sunday at 6 AM UTC
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/docs/actions_workflows.md
+++ b/docs/actions_workflows.md
@@ -118,6 +118,31 @@ The following secrets may be required for the workflows to run successfully. The
 *   `CODECOV_TOKEN`: Required for uploading test coverage reports to Codecov.
 *   `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`: Required if you are pushing images to Docker Hub in the `deploy.yml` workflow.
 
+### Auto-Assign Configuration
+
+The `automation.yml` workflow includes auto-assignment functionality that can automatically assign team members to issues and pull requests based on labels. To configure this:
+
+*   `BACKEND_MAINTAINER`: GitHub username for backend-related issues/PRs
+*   `FRONTEND_MAINTAINER`: GitHub username for frontend-related issues/PRs  
+*   `DEVOPS_MAINTAINER`: GitHub username for devops/infrastructure-related issues/PRs
+*   `SECURITY_MAINTAINER`: GitHub username for security-related issues/PRs
+
+**Note**: If these secrets are not configured, the workflow will default to assigning the repository owner (`argakiig`). Make sure the configured usernames have access to the repository.
+
+#### Setting Up Auto-Assign Secrets
+
+1. Go to your repository's "Settings" > "Secrets and variables" > "Actions"
+2. Click "New repository secret" for each maintainer role
+3. Add the following secrets with actual GitHub usernames:
+   - `BACKEND_MAINTAINER`: Username for backend issues
+   - `FRONTEND_MAINTAINER`: Username for frontend issues  
+   - `DEVOPS_MAINTAINER`: Username for devops/infrastructure issues
+   - `SECURITY_MAINTAINER`: Username for security issues
+
+**Example**: If your backend maintainer's GitHub username is `john-doe`, set `BACKEND_MAINTAINER` to `john-doe`.
+
+The auto-assign functionality will now work when issues or PRs are labeled with `backend`, `frontend`, `devops`, or `security`.
+
 ## 📊 Monitoring and Notifications
 
 ### Built-in Notifications


### PR DESCRIPTION
Potential fix for [https://github.com/StatusWise/statuswise/security/code-scanning/2](https://github.com/StatusWise/statuswise/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily reads repository contents and uploads coverage reports, the `contents: read` permission is sufficient for most jobs. For jobs that interact with external services (e.g., Codecov), additional permissions may be required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level to customize permissions for each job. In this case, we will add the block at the root level for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
